### PR TITLE
chore: Update dependencies to the latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
-    "@semantic-release/changelog": "^3.0.4",
-    "@semantic-release/git": "^7.0.12",
-    "eslint": "^6.0.0",
+    "@semantic-release/changelog": "^3.0.6",
+    "@semantic-release/git": "^7.0.18",
+    "eslint": "^6.7.2",
     "eslint-config-5app": "^0.8.0",
-    "husky": "^3.0.4",
-    "semantic-release": "^15.13.16"
+    "husky": "^3.1.0",
+    "semantic-release": "^15.13.31"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Update the npm dependencies of js-template to the latest versions.
There are no "major" updates.

noissue